### PR TITLE
feat: better default for library name

### DIFF
--- a/workflow-templates/lactame.yml
+++ b/workflow-templates/lactame.yml
@@ -20,5 +20,5 @@ jobs:
         uses: zakodium/lactame-action@v1
         with:
           token: ${{ secrets.LACTAME_TOKEN }}
-          name: LIBRARY_NAME
+          name: ${{ github.event.repository.name }}
           folder: dist


### PR DESCRIPTION
I think usually it will be the repository name on lactame, this is already known to the GitHub context.