### PR TITLE
feat: better default for package name

### DIFF
--- a/workflow-templates/lactame.yml
+++ b/workflow-templates/lactame.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Get package name
+        run: echo "PACKAGENAME=$(jq .name package.json | tr -d '"')" >> $GITHUB_ENV
       - uses: actions/setup-node@v2-beta
         with:
           node-version: 14.x
@@ -20,5 +22,5 @@ jobs:
         uses: zakodium/lactame-action@v1
         with:
           token: ${{ secrets.LACTAME_TOKEN }}
-          name: LIBRARY_NAME
+          name: "${{env.PACKAGENAME}}"
           folder: dist


### PR DESCRIPTION
- closed PR https://github.com/cheminfo/.github/pull/1 since Luc mentioned that often package name is not equal to repo name
- for this reason, we try to get package name from the `package.json`
- tested here: https://github.com/cheminfo/isotherm-analysis/runs/1243960942?check_suite_focus=true