### PR TITLE
chore: `branches` need to be array

### DIFF
--- a/workflow-templates/nodejs.yml
+++ b/workflow-templates/nodejs.yml
@@ -2,7 +2,8 @@ name: Node.js CI
 
 on:
   push:
-    branches: $default-branch
+    branches: 
+      - $default-branch
   pull_request:
 
 env:


### PR DESCRIPTION
minor issue, throws an linter warning in VSCode
branches should be an array according to https://json.schemastore.org/github-workflow.json